### PR TITLE
Tidy Sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@ extensions = [
 templates_path = ["_templates"]
 source_suffix = ".md"
 master_doc = "index"
-html_extra_path = ["_extra"]
 
 project = "First Django Admin"
 year = datetime.now().year


### PR DESCRIPTION
## Summary
- Remove `html_extra_path = ["_extra"]` from `docs/conf.py`
- The referenced `docs/_extra` directory is not present, so this config entry only asks Sphinx to copy a missing extra path

## Validation
- `uv run --with sphinx==7.2.6 --with myst-parser==2.0.0 --with sphinx-palewire-theme==0.0.18 sphinx-build -b html ./docs /tmp/palewire_first-django-admin_sphinx_tidy_check --keep-going`

Note: strict `-W` validation still fails on pre-existing documentation warnings outside this config-only cleanup, including toctree/reference and code-block line-number warnings.
